### PR TITLE
Set connection timeout; allow overriding of timeout via SlackRequest attribute.

### DIFF
--- a/slackclient/_server.py
+++ b/slackclient/_server.py
@@ -64,7 +64,7 @@ class Server(object):
         return self.__str__()
 
     def rtm_connect(self, reconnect=False):
-        reply = self.api_requester.do("rtm.start", request_timeout=None)
+        reply = self.api_requester.do("rtm.start", read_timeout=None)
         if reply.status_code != 200:
             raise SlackConnectionError
         else:

--- a/slackclient/_server.py
+++ b/slackclient/_server.py
@@ -25,7 +25,7 @@ class Server(object):
         self.connected = False
         self.pingcounter = 0
         self.ws_url = None
-        self.api_requester = SlackRequest()
+        self.api_requester = SlackRequest(self.token)
 
         if connect:
             self.rtm_connect()
@@ -64,7 +64,7 @@ class Server(object):
         return self.__str__()
 
     def rtm_connect(self, reconnect=False):
-        reply = self.api_requester.do(self.token, "rtm.start")
+        reply = self.api_requester.do("rtm.start", request_timeout=None)
         if reply.status_code != 200:
             raise SlackConnectionError
         else:
@@ -167,7 +167,6 @@ class Server(object):
         Note: this action is not allowed by bots, they must be invited to channels.
         '''
         return self.api_requester.do(
-            self.token,
             "channels.join?name={}".format(name)
         ).text
 
@@ -201,7 +200,7 @@ class Server(object):
 
             See here for more information on responses: https://api.slack.com/web
         '''
-        return self.api_requester.do(self.token, method, kwargs).text
+        return self.api_requester.do(method, kwargs).text
 
 
 class SlackConnectionError(Exception):

--- a/slackclient/_slackrequest.py
+++ b/slackclient/_slackrequest.py
@@ -5,14 +5,23 @@ import six
 
 
 class SlackRequest(object):
+    def __init__(self, token):
+        self.token = token
+        self.connect_timeout = 3.05
+        self.request_timeout = 10
 
-    @staticmethod
-    def do(token, request="?", post_data=None, domain="slack.com"):
+    def do(
+        self,
+        request="?",
+        post_data=None,
+        domain="slack.com",
+        connect_timeout=None,
+        request_timeout=None,
+    ):
         '''
         Perform a POST request to the Slack Web API
 
         Args:
-            token (str): your authentication token
             request (str): the method to call from the Slack API. For example: 'channels.list'
             post_data (dict): key/value arguments to pass for the request. For example:
                 {'channel': 'CABC12345'}
@@ -21,12 +30,20 @@ class SlackRequest(object):
         '''
         post_data = post_data or {}
 
+        request_timeout = request_timeout or self.request_timeout
+        connect_timeout = connect_timeout or self.connect_timeout
+
         for k, v in six.iteritems(post_data):
             if not isinstance(v, six.string_types):
                 post_data[k] = json.dumps(v)
 
         url = 'https://{0}/api/{1}'.format(domain, request)
-        post_data['token'] = token
+        post_data['token'] = self.token
         files = {'file': post_data.pop('file')} if 'file' in post_data else None
 
-        return requests.post(url, data=post_data, files=files)
+        return requests.post(
+            url,
+            data=post_data,
+            files=files,
+            timeout=(connect_timeout, request_timeout, ),
+        )

--- a/slackclient/_slackrequest.py
+++ b/slackclient/_slackrequest.py
@@ -8,7 +8,7 @@ class SlackRequest(object):
     def __init__(self, token):
         self.token = token
         self.connect_timeout = 3.05
-        self.request_timeout = 10
+        self.read_timeout = 10
 
     def do(
         self,
@@ -16,7 +16,7 @@ class SlackRequest(object):
         post_data=None,
         domain="slack.com",
         connect_timeout=None,
-        request_timeout=None,
+        read_timeout=None,
     ):
         '''
         Perform a POST request to the Slack Web API
@@ -30,7 +30,7 @@ class SlackRequest(object):
         '''
         post_data = post_data or {}
 
-        request_timeout = request_timeout or self.request_timeout
+        read_timeout = read_timeout or self.read_timeout
         connect_timeout = connect_timeout or self.connect_timeout
 
         for k, v in six.iteritems(post_data):
@@ -45,5 +45,5 @@ class SlackRequest(object):
             url,
             data=post_data,
             files=files,
-            timeout=(connect_timeout, request_timeout, ),
+            timeout=(connect_timeout, read_timeout, ),
         )


### PR DESCRIPTION
**Note**: This PR is public, but entirely contained to our fork.

There was a bit of well-suppressed frustration in @vitaminmoo's words when he discovered that I was planning on having Airship report various important events to Slack.  His concerns, though, are reasonable, and we really do need to make absolutely sure that integrating with any third-party service not increase the probability of a PI occurring.

What this does:
- Allows specification of connection/read timeouts for use when interacting with Slack. Note that the values specified here are not the values that will be in use in our integration.
- Changes the implementation of `SlackRequest.do` both for simplicity and to make instance variable twiddling possible.
